### PR TITLE
Add Windows support

### DIFF
--- a/lib/cliCommand.js
+++ b/lib/cliCommand.js
@@ -3,8 +3,8 @@ var PLATFORM = {
     UNIX: 'UNIX'
 };
 
-function getPlatform(platformKey) {
-    switch (platformKey) {
+function getPlatform() {
+    switch (process.platform) {
         case 'win32':
         case 'win64':
             return PLATFORM.WINDOWS;
@@ -17,11 +17,11 @@ function getCdCommand() {
     switch (this.platform) {
         case PLATFORM.WINDOWS:
             return function cdToPath(folder) {
-                return 'cd ' + folder;
+                return 'cd \"' + folder + "\"";
             };
         case PLATFORM.UNIX:
             return function cdToPath(folder) {
-                return 'cd ' + folder;
+                return "cd '" + folder + "'";
             };
     }
 }
@@ -30,7 +30,10 @@ function getCleanseCommand(setEnvVar) {
     switch (this.platform) {
         case PLATFORM.WINDOWS:
             return function (cmd) {
-                return [setEnvVar(), cmd].join(' ');
+                var envCmd = setEnvVar();
+                if (!envCmd.length)
+                    return cmd;
+                return [envCmd, cmd].join(' ');
             };
         case PLATFORM.UNIX:
             return function (cmd) {
@@ -60,13 +63,7 @@ function getConcatenator() {
     switch(this.platform) {
         case PLATFORM.WINDOWS:
             return function (cmds) {
-                var cmdText = '';
-                for (var i = 0; i < cmds.length; i++) {
-                    cmdText += cmds[i];
-                    if (i < cmds.length - 1)
-                        cmdText += " && ";
-                }
-                return cmdText;
+                return cmds.join(" && ");
             };
         case PLATFORM.UNIX:
             return function (cmds) {
@@ -81,8 +78,8 @@ function getConcatenator() {
     }
 }
 
-var cliCommand = (function getExecutor(platformKey) {
-    this.platform = getPlatform(platformKey);
+var cliCommand = (function getExecutor() {
+    this.platform = getPlatform();
 
     var cdTo = getCdCommand.call(this);
     var concat = getConcatenator.call(this);
@@ -96,6 +93,6 @@ var cliCommand = (function getExecutor(platformKey) {
 
         return concat(cmds);
     }
-})(process.platform);
+})();
 
 module.exports = cliCommand;

--- a/lib/cliCommand.js
+++ b/lib/cliCommand.js
@@ -1,0 +1,101 @@
+var PLATFORM = {
+    WINDOWS: 'WINDOWS',
+    UNIX: 'UNIX'
+};
+
+function getPlatform(platformKey) {
+    switch (platformKey) {
+        case 'win32':
+        case 'win64':
+            return PLATFORM.WINDOWS;
+        default:
+            return PLATFORM.UNIX;
+    }
+}
+
+function getCdCommand() {
+    switch (this.platform) {
+        case PLATFORM.WINDOWS:
+            return function cdToPath(folder) {
+                return 'cd ' + folder;
+            };
+        case PLATFORM.UNIX:
+            return function cdToPath(folder) {
+                return 'cd ' + folder;
+            };
+    }
+}
+
+function getCleanseCommand(setEnvVar) {
+    switch (this.platform) {
+        case PLATFORM.WINDOWS:
+            return function (cmd) {
+                return [setEnvVar(), cmd].join(' ');
+            };
+        case PLATFORM.UNIX:
+            return function (cmd) {
+                return [setEnvVar("LC_ALL", "en_US.UTF-8"), cmd].join(' ');
+            };
+    }
+}
+
+function getSetEnv() {
+    switch (this.platform) {
+        case PLATFORM.WINDOWS:
+            return function (k, v) {
+                if (!k)
+                    return "";
+                return "SET ".concat([k,v].join('='));
+            };
+        case PLATFORM.UNIX:
+            return function (k, v) {
+                if (!k)
+                    return "";
+                return [k,v].join('=');
+            };
+    }
+}
+
+function getConcatenator() {
+    switch(this.platform) {
+        case PLATFORM.WINDOWS:
+            return function (cmds) {
+                var cmdText = '';
+                for (var i = 0; i < cmds.length; i++) {
+                    cmdText += cmds[i];
+                    if (i < cmds.length - 1)
+                        cmdText += " && ";
+                }
+                return cmdText;
+            };
+        case PLATFORM.UNIX:
+            return function (cmds) {
+                var cmdText = '';
+                for (var i = 0; i < cmds.length; i++) {
+                    cmdText += cmds[i];
+                    if (i < cmds.length - 1)
+                        cmdText += ";";
+                }
+                return cmdText;
+            };
+    }
+}
+
+var cliCommand = (function getExecutor(platformKey) {
+    this.platform = getPlatform(platformKey);
+
+    var cdTo = getCdCommand.call(this);
+    var concat = getConcatenator.call(this);
+    var setEnvVar = getSetEnv.call(this);
+    var cleanse = getCleanseCommand.call(this, setEnvVar);
+
+    return function (folder, cmd) {
+        var cmds = [];
+        cmds.push(cdTo(folder));
+        cmds.push(cleanse(cmd));
+
+        return concat(cmds);
+    }
+})(process.platform);
+
+module.exports = cliCommand;

--- a/lib/git/git.js
+++ b/lib/git/git.js
@@ -9,6 +9,7 @@ var _ = {
   findIndex: require('lodash.findindex'),
 };
 var helper = require('../helper.js');
+var cliCommand = require('../cliCommand.js');
 var jsGitService = require('./js-git-service.js');
 
 var git = {};
@@ -55,7 +56,7 @@ git.getCommitInfo = function (folder, data, cb) {
 };
 
 git.getStaged = function (folder, data, cb) {
-  exec("cd '" + folder + "';LC_ALL=en_US.UTF-8 git status -s", {timeout: TIMEOUT, maxBuffer: MAXBUFFER},
+  exec(cliCommand(folder, 'git status -s'), {timeout: TIMEOUT, maxBuffer: MAXBUFFER},
     function (err, stdout, stderr) {
       if (err) {
         return cb(err);
@@ -152,7 +153,7 @@ git.getUpdateTime = function (folder, data, cb) {
 };
 
 git.getTags = function (folder, data, cb) {
-  exec("cd '" + folder + "';LC_ALL=en_US.UTF-8 git tag", {timeout: TIMEOUT, maxBuffer: MAXBUFFER},
+    exec(cliCommand(folder, 'git tag'), {timeout: TIMEOUT, maxBuffer: MAXBUFFER},
     function (err, stdout, stderr) {
       if (err) {
         return cb(err);
@@ -199,7 +200,7 @@ git.isUpdated = function (folder, cb) {
         return cb(err);
       }
 
-      exec("cd '" + folder + "';LC_ALL=en_US.UTF-8 git remote update", {timeout: 60000, maxBuffer: MAXBUFFER},
+      exec(cliCommand(folder, 'git remote update'), {timeout: 60000, maxBuffer: MAXBUFFER},
         function (err, stdout, stderr) {
           if (err) {
             return cb(err);
@@ -224,7 +225,7 @@ git.isUpdated = function (folder, cb) {
 
 git.revert = function (args, cb) {
   var ret = {};
-  var command = "cd '" + args.folder + "';LC_ALL=en_US.UTF-8 git reset --hard " + args.revision;
+  var command = cliCommand(args.folder, "git reset --hard " + args.revision);
   ret.output = '';
   ret.output += command + '\n';
   ret.success = true;

--- a/lib/hg/hg.js
+++ b/lib/hg/hg.js
@@ -2,6 +2,8 @@ var exec = require("child_process").exec;
 
 var fs   = require("fs");
 
+var cliCommand = require('../cliCommand.js');
+
 var halt = false;
 
 function error(repoType, task, errorMsg, cb) {
@@ -33,7 +35,7 @@ module.exports.parse = function parseHg(folder, cb) {
   data.type = 'mercurial';
   data.commit_history = []; // temporary
 
-	exec("cd '"+folder+"';LC_ALL=en_US.UTF-8 hg paths default", function(err, stdout, stderr) {
+	exec(cliCommand(folder, "hg paths default"), function(err, stdout, stderr) {
 		if(err !== null) {
 			error("mercurial", "fetching path", stderr, cb);
 		}
@@ -42,7 +44,7 @@ module.exports.parse = function parseHg(folder, cb) {
 			checkReturn(data, cb);
 		}
 	});
-	exec("cd '"+folder+"';LC_ALL=en_US.UTF-8 hg log --limit 1 --template 'changeset: {rev}:{node|short}\nsummary: {desc}'", function(err, stdout, stderr) {
+	exec(cliCommand(folder, "hg log --limit 1 --template 'changeset: {rev}:{node|short}\nsummary: {desc}'"), function(err, stdout, stderr) {
 		if(err !== null) {
 			error("mercurial", "fetching log", stderr, cb);
 		}
@@ -56,7 +58,7 @@ module.exports.parse = function parseHg(folder, cb) {
 			checkReturn(data, cb);
 		}
 	});
-	exec("cd '"+folder+"';LC_ALL=en_US.UTF-8 hg branch", function(err, stdout, stderr) {
+	exec(cliCommand(folder, "hg branch"), function(err, stdout, stderr) {
 		if(err !== null) {
 			error("mercurial", "fetching branch", stderr, cb);
 		}

--- a/lib/svn/svn.js
+++ b/lib/svn/svn.js
@@ -2,11 +2,13 @@ var fs = require('fs');
 var async = require('async');
 var exec = require('child_process').exec;
 
+var cliCommand = require('../cliCommand.js');
+
 var svn = {};
 
 svn.parse = function(folder, cb) {
   var getMeta = function(cb) {
-    exec("cd '"+folder+"';LC_ALL=en_US.UTF-8 svn info", function(err, stdout, stderr) {
+    exec(cliCommand(folder, "svn info"), function(err, stdout, stderr) {
       if(err !== null)
         return cb(err);
       var data = {};
@@ -22,7 +24,7 @@ svn.parse = function(folder, cb) {
   }
 
   var getRevComment = function(data, cb) {
-    exec("cd '"+folder+"';LC_ALL=en_US.UTF-8 svn log -r BASE", function(err, stdout, stderr) {
+    exec(cliCommand(folder, "svn log -r BASE"), function(err, stdout, stderr) {
       if(err !== null)
         return cb(err);
       data.revision = stdout.match(/^(r[0-9]+)\s\|/m);
@@ -59,11 +61,11 @@ svn.isUpdated = function(folder, cb) {
     return matches;
   }
 
-  exec("cd '"+folder+"';LC_ALL=en_US.UTF-8 svn info", function(err, stdout, stderr) {
+  exec(cliCommand(folder, "svn info"), function(err, stdout, stderr) {
     if(err !== null)
       return cb(err);
     var current_rev = getRev(stdout);
-    exec("cd '"+folder+"';LC_ALL=en_US.UTF-8 svn info -r HEAD", function(err, stdout, stderr) {
+    exec(cliCommand(folder, "svn info -r HEAD"), function(err, stdout, stderr) {
       if(err !== null)
         return cb(err);
       var recent_rev = getRev(stdout);
@@ -78,7 +80,7 @@ svn.isUpdated = function(folder, cb) {
 svn.update = function(folder, cb) {
   var res = {};
 
-  exec("cd '"+folder+"';LC_ALL=en_US.UTF-8 svn update", function(err, stdout, stderr) {
+  exec(cliCommand(folder, "svn update"), function(err, stdout, stderr) {
     if(err !== null)
       return cb(err);
     var new_rev = stdout.match(/Updated to revision ([^\.]+)/);

--- a/lib/vizion.js
+++ b/lib/vizion.js
@@ -11,9 +11,6 @@ var identify = require('./identify.js');
 vizion.analyze = function(argv, cb) {
   var _folder = (argv.folder != undefined) ? argv.folder : '.';
 
-  if (process.platform === 'win32' || process.platform === 'win64')
-    return cb('vizion is not yet compatible with Windows.');
-
   identify(_folder, function(type, folder) {
     if (ALL[type])
       return ALL[type].parse(folder, cb);

--- a/test/functional/cliCommand.test.js
+++ b/test/functional/cliCommand.test.js
@@ -1,0 +1,31 @@
+var expect = require('chai').expect;
+var fs = require('fs');
+var sinon = require('sinon');
+var ini = require('ini');
+
+var cliCommand = require("../../lib/cliCommand.js");
+
+describe('Unit: cliCommand', function () {
+
+    describe("getPlatform", function () {
+
+        var tmp = process.platform;
+
+        before(function () {
+            process.platform = "win32";
+        });
+
+        it("recognizes win32/64 systems", function () {
+            var r1 =
+        });
+
+        after(function () {
+            process.platform = tmp;
+        });
+
+        it("decides on Unix for all other systems", function () {
+
+        });
+    });
+
+});

--- a/test/functional/cliCommand.test.js
+++ b/test/functional/cliCommand.test.js
@@ -1,31 +1,21 @@
 var expect = require('chai').expect;
-var fs = require('fs');
-var sinon = require('sinon');
-var ini = require('ini');
-
 var cliCommand = require("../../lib/cliCommand.js");
 
-describe('Unit: cliCommand', function () {
+describe('Functional: cliCommand', function () {
 
-    describe("getPlatform", function () {
+    var folderWindows = "C:\\Program Files\\nodejs\\foobar";
+    var folderUnix = "/etc/node/foobar";
 
-        var tmp = process.platform;
+    it("ok", function () {
+        var target;
 
-        before(function () {
-            process.platform = "win32";
-        });
+        if (/^win/.exec(process.platform))
+            target = "cd \"" + folderWindows + "\" && git status -s";
+        else
+            target = "cd '" + folderUnix + "';LC_ALL=en_US.UTF-8 git status -s";
 
-        it("recognizes win32/64 systems", function () {
-            var r1 =
-        });
-
-        after(function () {
-            process.platform = tmp;
-        });
-
-        it("decides on Unix for all other systems", function () {
-
-        });
+        var result = cliCommand(folderWindows, "git status -s");
+        expect(target).to.eq(result);
     });
 
 });

--- a/test/functional/cliCommand.test.js
+++ b/test/functional/cliCommand.test.js
@@ -3,18 +3,20 @@ var cliCommand = require("../../lib/cliCommand.js");
 
 describe('Functional: cliCommand', function () {
 
-    var folderWindows = "C:\\Program Files\\nodejs\\foobar";
-    var folderUnix = "/etc/node/foobar";
-
     it("ok", function () {
-        var target;
+        var target, folder;
 
-        if (/^win/.exec(process.platform))
-            target = "cd \"" + folderWindows + "\" && git status -s";
-        else
-            target = "cd '" + folderUnix + "';LC_ALL=en_US.UTF-8 git status -s";
+        if (/^win/.exec(process.platform)) {
+            folder = "C:\\Program Files\\nodejs\\foobar";
+            target = "cd \"" + folder + "\" && git status -s";
+        }
+        else {
+            folder = "/etc/node/foobar";
+            target = "cd '" + folder + "';LC_ALL=en_US.UTF-8 git status -s";
+        }
 
-        var result = cliCommand(folderWindows, "git status -s");
+
+        var result = cliCommand(folder, "git status -s");
         expect(target).to.eq(result);
     });
 

--- a/test/unit/git.test.js
+++ b/test/unit/git.test.js
@@ -17,7 +17,10 @@ describe('Unit: git', function () {
 
     before(function beforeTest() {
       readFileStub = sinon.stub(fs, 'readFile', function (path, encoding, cb) {
-        expect(path).to.eq('my-folder/.git/config');
+        if (process.platform !== 'win32' && process.platform !== 'win64')
+          expect(path).to.eq('my-folder/.git/config');
+        else
+          expect(path).to.eq('my-folder\\.git\\config');
 
         cb(null, data);
       });
@@ -126,7 +129,10 @@ describe('Unit: git', function () {
 
     before(function beforeTest() {
       readFileStub = sinon.stub(fs, 'readFile', function (path, encoding, cb) {
-        expect(path).to.eq('my-folder/.git/HEAD');
+        if (process.platform !== 'win32' && process.platform !== 'win64')
+            expect(path).to.eq('my-folder/.git/HEAD');
+        else
+            expect(path).to.eq('my-folder\\.git\\HEAD');
         expect(encoding).to.eq('utf-8');
 
         cb(null, "ref: refs/heads/master");


### PR DESCRIPTION
Hi folks, 

Last night, I did watch the presentation about PM2 and Keymetrics and I asked a question mainly concerning any plans targeting full SVN support within PM2. The answer was that there are currently no plans to do so but pull requests are welcome.

So since we develop and run products both on Windows systems, I wanted to lay the foundation by at least making git usable for updates on Windows.

This is a quick solution that actually does not use shelljs (because I do not know it well enough yet). Maybe it fits the need.