### PR TITLE
fixed bugs in svn.parse function

### DIFF
--- a/lib/svn/svn.js
+++ b/lib/svn/svn.js
@@ -16,26 +16,50 @@ svn.parse = function(folder, cb) {
       data.url = stdout.match(/Repository Root: ([^\n]+)/);
       if (data.url && typeof(data.url) === 'object') {
         data.url = data.url[1];
-        data.branch = typeof(data.url) === 'string' ? data.url.match(/[^/]+$/) : null;
       }
-      if (data.branch) data.branch = data.branch[0];
+      var match = stdout.match(/Relative URL: \^\/([^\n]+)/);
+      if (match) {
+        var relativeUrl = match[1];
+        if (relativeUrl.match(/^trunk/)) {
+          data.branch = 'trunk';
+        } else if (relativeUrl.match(/^branch/)) {
+          match = relativeUrl.match(/^branch(?:es)?\/([^/]+)(?:\/|$)/);
+          if (match) {
+            data.branch = match[1];
+          }
+        }
+      }
+      match = stdout.match(/Last Changed Rev: ([^\n]+)/);
+      if (match) {
+        data.revision = match[1];
+      }
+      match = stdout.match(/Last Changed Date: ([^\n]+)/);
+      if (match) {
+        var date = new Date(match[1]);
+        data.update_time = date;
+      }
       return cb(null, data);
     });
   }
 
   var getRevComment = function(data, cb) {
-    exec(cliCommand(folder, "svn log -r BASE"), function(err, stdout, stderr) {
+    var rev = data.revision || "BASE";
+    exec(cliCommand(folder, "svn log -r " + rev), function(err, stdout, stderr) {
       if(err !== null)
         return cb(err);
-      data.revision = stdout.match(/^(r[0-9]+)\s\|/m);
+      if (rev === "BASE") {
+        data.revision = stdout.match(/^(r[0-9]+)\s\|/m);
+        if (data.revision) data.revision = data.revision[1];
+      }
       data.comment = stdout.match(/lines?\s*\n((.|\n)*)\n-{72}\n$/);
-      if (data.revision) data.revision = data.revision[1];
       if (data.comment) data.comment = data.comment[1].replace(/\n/g, '');
       cb(null, data);
     });
   }
 
   var getDate = function(data, cb) {
+    if (data.update_time)
+      return cb(null, data);
     fs.stat(folder+".svn", function(err, stats) {
       if(err !== null)
         return cb(err);

--- a/lib/svn/svn.js
+++ b/lib/svn/svn.js
@@ -53,6 +53,12 @@ svn.parse = function(folder, cb) {
       }
       data.comment = stdout.match(/lines?\s*\n((.|\n)*)\n-{72}\n$/);
       if (data.comment) data.comment = data.comment[1].replace(/\n/g, '');
+      if (!data.update_time) {
+        data.update_time = stdout.match(/-+\n(.*?)\n/);
+        if (data.update_time) data.update_time = new Date(
+          data.update_time[1].split(" | ")[2]
+        );
+      }
       cb(null, data);
     });
   }


### PR DESCRIPTION
Fixes #22.

Parses the branch name from the _Relative URL_ line in the `svn info` output to correct the bug that showed the repo name as the branch name.

Parses the revision from the _Last Changed Rev_ line in the `svn info` output. Falls back to getting the revision from the `svn log -r BASE` command as before, just in case the _Last Changed Rev_ line is not output by older versions of the svn command.

Parses the update_time from the _Last Changed Date_ line in the `svn info` output. Falls back to parsing the date from the `svn log` command. Lastly, falls back to stating the `.svn` folder as before.